### PR TITLE
Rectify issue in Parser class

### DIFF
--- a/src/main/java/seedu/splitlah/parser/Parser.java
+++ b/src/main/java/seedu/splitlah/parser/Parser.java
@@ -251,7 +251,7 @@ public class Parser {
     public static String getRemainingArgument(String commandArgs) {
         String[] commandTokens = commandArgs.trim().split(REGEX_WHITESPACES_DELIMITER, COMMAND_WITH_ARGS_TOKEN_COUNT);
         if (commandTokens.length < COMMAND_WITH_ARGS_TOKEN_COUNT) {
-            return null;
+            return "";
         }
         return commandTokens[2];
     }


### PR DESCRIPTION
Change return value for empty argument to empty string
Previously return value was null, resulting in NullPointerException when no arguments were given when expected one.