### PR TITLE
Add JUnit tests for Parser class

### DIFF
--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -31,6 +31,10 @@ class ParserTest {
     }
 
     // getCommandType()
+    /**
+     * Checks if an empty String object is returned as the command string
+     * when an empty String object is provided by the user.
+     */
     @Test
     void getCommandType_emptyStringInput_emptyString() {
         String emptyString = "";
@@ -38,6 +42,11 @@ class ParserTest {
         assertEquals("", output);
     }
 
+    /**
+     * Checks if a String object containing identical contents as the input is returned as the command string
+     * when a single token of input is provided by the user.
+     * Matching command types: "help", "list", "exit"
+     */
     @Test
     void getCommandType_singleTokenInput_inputEqualsOutput() {
         String singleTokenString = "randomTest123";
@@ -45,6 +54,11 @@ class ParserTest {
         assertEquals(singleTokenString, output);
     }
 
+    /**
+     * Checks if null is returned when an input, with a second token does not start with a delimiter,
+     * is provided by the user.
+     */
+    @Test
     void getCommandType_doubleTokenNoDelimiterInput_null() {
         String doubleTokenWithNoDelimiterString = "help apple";
         String output = Parser.getCommandType(doubleTokenWithNoDelimiterString);

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -66,6 +66,10 @@ class ParserTest {
     }
 
     // getRemainingArgument()
+    /**
+     * Checks if an empty String object is returned as the remaining arguments of the command
+     * when an empty String object is provided by the user.
+     */
     @Test
     void getRemainingArgument_emptyStringInput_emptyString() {
         String emptyString = "";
@@ -73,6 +77,10 @@ class ParserTest {
         assertEquals("", output);
     }
 
+    /**
+     * Checks if an empty String object is returned as the remaining arguments of the command
+     * when an input of only a single token is provided by the user.
+     */
     @Test
     void getRemainingArgument_singleTokenInput_emptyString() {
         String singleTokenString = "randomTest123";
@@ -80,6 +88,10 @@ class ParserTest {
         assertEquals("", output);
     }
 
+    /**
+     * Checks if an empty String object is returned as the remaining arguments of the command
+     * when an input of only two tokens is provided by the user.
+     */
     @Test
     void getRemainingArgument_twoInputTokens_emptyString() {
         String twoInputTokensString = "brownFox jumpsOver";
@@ -87,6 +99,10 @@ class ParserTest {
         assertEquals("", output);
     }
 
+    /**
+     * Checks if the third token is correctly returned as the remaining arguments of the command
+     * when an input of three tokens and multiple whitespaces is provided by the user.
+     */
     @Test
     void getRemainingArgument_threeInputTokensAndWhitespace_thirdToken() {
         String threeInputTokensAndWhitespaceString = "brownFox jumpsOver theLazyDog  ";
@@ -94,6 +110,10 @@ class ParserTest {
         assertEquals("theLazyDog", output);
     }
 
+    /**
+     * Checks if the third token and onwards is correctly returned as the remaining arguments of the command
+     * when an input of four tokens is provided by the user.
+     */
     @Test
     void getRemainingArgument_fourInputTokens_thirdToken() {
         String fourInputTokensString = "brownFox jumpsOver theLazy Dog";

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -1,0 +1,12 @@
+package seedu.splitlah.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.splitlah.command.Command;
+import seedu.splitlah.command.InvalidCommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ParserTest {
+
+}

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -30,4 +30,24 @@ class ParserTest {
         assertEquals(InvalidCommand.class, command.getClass());
     }
 
+    // getCommandType()
+    @Test
+    void getCommandType_emptyStringInput_emptyString() {
+        String emptyString = "";
+        String output = Parser.getCommandType(emptyString);
+        assertEquals("", output);
+    }
+
+    @Test
+    void getCommandType_singleTokenInput_inputEqualsOutput() {
+        String singleTokenString = "randomTest123";
+        String output = Parser.getCommandType(singleTokenString);
+        assertEquals(singleTokenString, output);
+    }
+
+    void getCommandType_doubleTokenNoDelimiterInput_null() {
+        String doubleTokenWithNoDelimiterString = "help apple";
+        String output = Parser.getCommandType(doubleTokenWithNoDelimiterString);
+        assertNull(output);
+    }
 }

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -64,4 +64,40 @@ class ParserTest {
         String output = Parser.getCommandType(doubleTokenWithNoDelimiterString);
         assertNull(output);
     }
+
+    // getRemainingArgument()
+    @Test
+    void getRemainingArgument_emptyStringInput_emptyString() {
+        String emptyString = "";
+        String output = Parser.getRemainingArgument(emptyString);
+        assertEquals("", output);
+    }
+
+    @Test
+    void getRemainingArgument_singleTokenInput_emptyString() {
+        String singleTokenString = "randomTest123";
+        String output = Parser.getRemainingArgument(singleTokenString);
+        assertEquals("", output);
+    }
+
+    @Test
+    void getRemainingArgument_twoInputTokens_emptyString() {
+        String twoInputTokensString = "brownFox jumpsOver";
+        String output = Parser.getRemainingArgument(twoInputTokensString);
+        assertEquals("", output);
+    }
+
+    @Test
+    void getRemainingArgument_threeInputTokensAndWhitespace_thirdToken() {
+        String threeInputTokensAndWhitespaceString = "brownFox jumpsOver theLazyDog  ";
+        String output = Parser.getRemainingArgument(threeInputTokensAndWhitespaceString);
+        assertEquals("theLazyDog", output);
+    }
+
+    @Test
+    void getRemainingArgument_fourInputTokens_thirdToken() {
+        String fourInputTokensString = "brownFox jumpsOver theLazy Dog";
+        String output = Parser.getRemainingArgument(fourInputTokensString);
+        assertEquals("theLazy Dog", output);
+    }
 }

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -9,4 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ParserTest {
 
+    // getCommand()
+    @Test
+    void getCommand_emptyString_InvalidCommand() {
+        String emptyString = "";
+        Command command = Parser.getCommand(emptyString);
+        assertEquals(InvalidCommand.class, command.getClass());
+    }
+
+    @Test
+    void getCommand_whitespaceInput_InvalidCommand() {
+        String whitespaceString = "     ";
+        Command command = Parser.getCommand(whitespaceString);
+        assertEquals(InvalidCommand.class, command.getClass());
+    }
+
 }

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -10,6 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ParserTest {
 
     // getCommand()
+    /**
+     * Checks if an InvalidCommand is returned when an empty String object is provided by the user.
+     */
     @Test
     void getCommand_emptyString_InvalidCommand() {
         String emptyString = "";
@@ -17,6 +20,9 @@ class ParserTest {
         assertEquals(InvalidCommand.class, command.getClass());
     }
 
+    /**
+     * Checks if an InvalidCommand is returned when a String object containing only whitespaces is provided by the user.
+     */
     @Test
     void getCommand_whitespaceInput_InvalidCommand() {
         String whitespaceString = "     ";


### PR DESCRIPTION
Add basic JUnit tests for getCommand(), getCommandType() and getRemainingArgument() methods.

Fixes #151 