### PR TITLE
Fix unitialized list bug in Person class

### DIFF
--- a/src/main/java/seedu/splitlah/data/Person.java
+++ b/src/main/java/seedu/splitlah/data/Person.java
@@ -21,6 +21,7 @@ public class Person {
      * @param name Name of the Person.
      */
     public Person(String name) {
+        this.activityCostList = new ArrayList<>();
         this.name = name;
     }
 


### PR DESCRIPTION
The list of activityCost objects was not being initialised in the
constructor, causing all accesses to this list to cause errors.

Let's initialise the list in the constructor to solve this.

Fixes #162 