### PR TITLE
Modify parseGst() and parseServiceCharge() in Parser class to support decimal points

### DIFF
--- a/src/main/java/seedu/splitlah/command/ActivityCreateCommand.java
+++ b/src/main/java/seedu/splitlah/command/ActivityCreateCommand.java
@@ -52,8 +52,8 @@ public class ActivityCreateCommand extends Command {
     private String payer;
     private String[] involvedList;
     private double[] costList;
-    private int gst;
-    private int serviceCharge;
+    private double gst;
+    private double serviceCharge;
 
     private static final double ZERO_COST_PAID = 0;
     public static final double ZERO_COST_OWED = 0;
@@ -72,7 +72,7 @@ public class ActivityCreateCommand extends Command {
      * @param serviceCharge The service charge to be included for the cost of the activity.
      */
     public ActivityCreateCommand(int sessionId, String activityName, double totalCost, String payer,
-                                 String[] involvedList, double[] costList, int gst, int serviceCharge) {
+                                 String[] involvedList, double[] costList, double gst, double serviceCharge) {
         assert sessionId > 0 : Message.ASSERT_ACTIVITYCREATE_SESSION_ID_LESS_THAN_ONE;
         assert activityName != null : Message.ASSERT_ACTIVITYCREATE_ACTIVITY_NAME_MISSING;
         assert payer != null : Message.ASSERT_ACTIVITYCREATE_PAYER_NAME_MISSING;
@@ -101,8 +101,8 @@ public class ActivityCreateCommand extends Command {
         String[] involvedList;
         double totalCost = 0;
         double[] costList = null;
-        int gst;
-        int serviceCharge;
+        double gst;
+        double serviceCharge;
 
         try {
             sessionId = Parser.parseSessionId(commandArgs);

--- a/src/main/java/seedu/splitlah/command/ActivityCreateCommand.java
+++ b/src/main/java/seedu/splitlah/command/ActivityCreateCommand.java
@@ -305,8 +305,8 @@ public class ActivityCreateCommand extends Command {
      * @return A double representing the extra charges.
      */
     private double getExtraCharges() {
-        double gstMultiplier = 1 + (double) gst / 100;
-        double serviceChargeMultiplier = 1 + (double) serviceCharge / 100;
+        double gstMultiplier = 1 + gst / 100;
+        double serviceChargeMultiplier = 1 + serviceCharge / 100;
         return gstMultiplier * serviceChargeMultiplier;
     }
 

--- a/src/main/java/seedu/splitlah/parser/Parser.java
+++ b/src/main/java/seedu/splitlah/parser/Parser.java
@@ -221,15 +221,17 @@ public class Parser {
     }
 
     /**
-     * Returns an integer that represents the GST charge in percents, given the command arguments from user input, 
+     * Returns a double that represents the GST charge in percents, given the command arguments from user input, 
      * delimited by the GST delimiter.
      *
      * @param commandArgs A String object containing the arguments portion of the entire command input from the user.
-     * @return An integer that represents a GST charge in percents.
+     * @return A double that represents a GST charge in percents.
      * @throws InvalidFormatException If no arguments representing a GST charge were provided after the 
      *                                GST delimiter,
-     *                                if the argument cannot be parsed as an integer, or
-     *                                if the parsed GST percentage is not in [0, 100].
+     *                                if the argument cannot be parsed as a double,
+     *                                if the parsed percentage has more than 2 decimal points,
+     *                                if the parsed percentage has more than 3 digits before the decimal point, or
+     *                                if the parsed percentage is not in [0, 100].
      */
     public static double parseGst(String commandArgs) throws InvalidFormatException {
         if (!ParserUtils.hasDelimiter(commandArgs, ParserUtils.GST_DELIMITER)) {
@@ -245,15 +247,17 @@ public class Parser {
     }
 
     /**
-     * Returns an integer that represents the service charge in percents, given the command arguments from user input, 
+     * Returns a double that represents the service charge in percents, given the command arguments from user input, 
      * delimited by the Service charge delimiter.
      *
      * @param commandArgs A String object containing the arguments portion of the entire command input from the user.
-     * @return An integer that represents a service charge in percents.
+     * @return A double that represents a service charge in percents.
      * @throws InvalidFormatException If no arguments representing a service charge were provided after the 
      *                                Service charge delimiter,
-     *                                if the argument cannot be parsed as an integer, or
-     *                                if the parsed service charge percentage is not in [0, 100].
+     *                                if the argument cannot be parsed as a double,
+     *                                if the parsed percentage has more than 2 decimal points,
+     *                                if the parsed percentage has more than 3 digits before the decimal point, or
+     *                                if the parsed percentage is not in [0, 100].
      */
     public static double parseServiceCharge(String commandArgs) throws InvalidFormatException {
         if (!ParserUtils.hasDelimiter(commandArgs, ParserUtils.SERVICE_CHARGE_DELIMITER)) {

--- a/src/main/java/seedu/splitlah/parser/Parser.java
+++ b/src/main/java/seedu/splitlah/parser/Parser.java
@@ -31,8 +31,8 @@ public class Parser {
     private static final String LOCALDATE_TODAY_INDICATOR = "today";
     private static final int COMMAND_WITH_ARGS_TOKEN_COUNT = 3;
     private static final int DELIMITERED_COMMAND_MIN_TOKEN_COUNT = 2;
-    private static final int MINIMUM_SURCHARGE_PERCENT = 0;
-    private static final int MAXIMUM_SURCHARGE_PERCENT = 100;
+    static final double MINIMUM_SURCHARGE_PERCENT = 0;
+    static final double MAXIMUM_SURCHARGE_PERCENT = 100;
     
     // MAIN PUBLIC PARSING FUNCTIONS
     /**
@@ -231,13 +231,13 @@ public class Parser {
      *                                if the argument cannot be parsed as an integer, or
      *                                if the parsed GST percentage is not in [0, 100].
      */
-    public static int parseGst(String commandArgs) throws InvalidFormatException {
+    public static double parseGst(String commandArgs) throws InvalidFormatException {
         if (!ParserUtils.hasDelimiter(commandArgs, ParserUtils.GST_DELIMITER)) {
             return 0;
         }
 
         String argument = ParserUtils.getArgumentFromDelimiter(commandArgs, ParserUtils.GST_DELIMITER);
-        int gst = ParserUtils.parseIntFromString(argument, ParserUtils.GST_DELIMITER);
+        double gst = ParserUtils.parsePercentageFromString(argument, ParserUtils.GST_DELIMITER);
         if (gst < MINIMUM_SURCHARGE_PERCENT || gst > MAXIMUM_SURCHARGE_PERCENT) {
             throw new InvalidFormatException(ParserErrors.getInvalidGstErrorMessage());
         }
@@ -255,13 +255,13 @@ public class Parser {
      *                                if the argument cannot be parsed as an integer, or
      *                                if the parsed service charge percentage is not in [0, 100].
      */
-    public static int parseServiceCharge(String commandArgs) throws InvalidFormatException {
+    public static double parseServiceCharge(String commandArgs) throws InvalidFormatException {
         if (!ParserUtils.hasDelimiter(commandArgs, ParserUtils.SERVICE_CHARGE_DELIMITER)) {
             return 0;
         }
 
         String argument = ParserUtils.getArgumentFromDelimiter(commandArgs, ParserUtils.SERVICE_CHARGE_DELIMITER);
-        int serviceCharge = ParserUtils.parseIntFromString(argument, ParserUtils.SERVICE_CHARGE_DELIMITER);
+        double serviceCharge = ParserUtils.parsePercentageFromString(argument, ParserUtils.SERVICE_CHARGE_DELIMITER);
         if (serviceCharge < MINIMUM_SURCHARGE_PERCENT || serviceCharge > MAXIMUM_SURCHARGE_PERCENT) {
             throw new InvalidFormatException(ParserErrors.getInvalidServiceChargeErrorMessage());
         }

--- a/src/main/java/seedu/splitlah/parser/ParserErrors.java
+++ b/src/main/java/seedu/splitlah/parser/ParserErrors.java
@@ -39,13 +39,24 @@ public class ParserErrors {
 
     /**
      * Returns a String object containing an error message when the parser is not able to read an input String object
-     * as a double.
+     * as a double to be used as a monetary value.
      *
      * @param delimiter A String object that represents a demarcation of a specific argument in the command.
      * @return A String object representing an error message for a non-double input.
      */
     static String getNonMonetaryErrorMessage(String delimiter) {
         return Message.ERROR_PARSER_NON_MONETARY_VALUE_ARGUMENT + delimiter;
+    }
+
+    /**
+     * Returns a String object containing an error message when the parser is not able to read an input String object
+     * as a double to be used as a percentage value.
+     *
+     * @param delimiter A String object that represents a demarcation of a specific argument in the command.
+     * @return A String object representing an error message for a non-double input.
+     */
+    static String getNonPercentageErrorMessage(String delimiter) {
+        return Message.ERROR_PARSER_NON_PERCENTAGE_ARGUMENT + delimiter;
     }
 
     /**

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -223,6 +223,20 @@ public class ParserUtils {
         return cost;
     }
 
+    /**
+     * Returns a double representing a percentage value, represented by the provided input String object.
+     *
+     * @param input     A String object that contains numeric characters or a single decimal point character,
+     *                  representing a percentage value.
+     * @param delimiter A String object that represents a demarcation of a specific argument in the command.
+     * @return An double representing a percentage value.
+     * @throws InvalidFormatException If the provided input String object contains characters other than numeric
+     *                                characters or a single decimal point character,
+     *                                and cannot be parsed as a double,
+     *                                if the double parsed from the input String object is not a positive value,
+     *                                if the parsed double has more than 2 decimal points, or
+     *                                if the parsed double has more than 3 digits before the decimal point.
+     */
     static double parsePercentageFromString(String input, String delimiter) throws InvalidFormatException {
         assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
         assert delimiter != null : Message.ASSERT_PARSER_DELIMITER_NULL;

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -192,7 +192,7 @@ public class ParserUtils {
      * @param input     A String object that contains numeric characters or a single decimal point character,
      *                  representing a cost value.
      * @param delimiter A String object that represents a demarcation of a specific argument in the command.
-     * @return An double representing a cost value.
+     * @return A double representing a cost value.
      * @throws InvalidFormatException If the provided input String object contains characters other than numeric
      *                                characters or a single decimal point character,
      *                                and cannot be parsed as a double,
@@ -229,7 +229,7 @@ public class ParserUtils {
      * @param input     A String object that contains numeric characters or a single decimal point character,
      *                  representing a percentage value.
      * @param delimiter A String object that represents a demarcation of a specific argument in the command.
-     * @return An double representing a percentage value.
+     * @return A double representing a percentage value.
      * @throws InvalidFormatException If the provided input String object contains characters other than numeric
      *                                characters or a single decimal point character,
      *                                and cannot be parsed as a double,

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -223,6 +223,29 @@ public class ParserUtils {
         return cost;
     }
 
+    static double parsePercentageFromString(String input, String delimiter) throws InvalidFormatException {
+        assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
+        assert delimiter != null : Message.ASSERT_PARSER_DELIMITER_NULL;
+
+        double percentage;
+        try {
+            percentage = Double.parseDouble(input);
+        } catch (NumberFormatException exception) {
+            throw new InvalidFormatException(ParserErrors.getNonPercentageErrorMessage(delimiter));
+        }
+
+        if (percentage < 0) {
+            throw new InvalidFormatException(Message.ERROR_PARSER_PERCENTAGE_NEGATIVE);
+        }
+        if (!hasAtMostTwoDecimalPlaces(input)) {
+            throw new InvalidFormatException(Message.ERROR_PARSER_PERCENTAGE_NOT_TWO_DP);
+        }
+        if (!hasAtMostGivenIntegerPlaces(input, PERCENTAGE_ALLOWED_INTEGER_PLACES)) {
+            throw new InvalidFormatException(Message.ERROR_PARSER_PERCENTAGE_MORE_THAN_THREE_DIGITS_BEFORE_DP);
+        }
+        return percentage;
+    }
+
     /**
      * Checks the provided String object which represents the command arguments for the existence of a specified
      * delimiter.

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -41,6 +41,7 @@ public class ParserUtils {
     private static final String NEXT_DELIMITER_INDICATOR = " /";
     private static final int ZERO_INDEXING_OFFSET = 1;
     private static final int PERCENTAGE_ALLOWED_INTEGER_PLACES = 3;
+    private static final int TWO_DECIMAL_PLACES = 2;
     static final String REGEX_WHITESPACES_DELIMITER = "\\s+";
     static final int INVALID_INDEX_INDICATOR = -1;
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
@@ -129,7 +130,6 @@ public class ParserUtils {
      */
     private static boolean hasAtMostTwoDecimalPlaces(String input) {
         assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
-        final int TWO_DECIMAL_PLACES = 2;
         
         try {
             double value = Double.parseDouble(input);

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -39,6 +39,8 @@ public class ParserUtils {
     // MISC CONSTANTS
     static final String DELIMITER_INDICATOR = "/";
     private static final String NEXT_DELIMITER_INDICATOR = " /";
+    private static final int ZERO_INDEXING_OFFSET = 1;
+    private static final int PERCENTAGE_ALLOWED_INTEGER_PLACES = 3;
     static final String REGEX_WHITESPACES_DELIMITER = "\\s+";
     static final int INVALID_INDEX_INDICATOR = -1;
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
@@ -127,6 +129,7 @@ public class ParserUtils {
      */
     private static boolean hasAtMostTwoDecimalPlaces(String input) {
         assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
+        final int TWO_DECIMAL_PLACES = 2;
         
         try {
             double value = Double.parseDouble(input);
@@ -138,8 +141,8 @@ public class ParserUtils {
         if (indexOfDecimal == INVALID_INDEX_INDICATOR) {
             return true;
         }
-        int decimalPlaces = input.length() - indexOfDecimal - 1;
-        return decimalPlaces <= 2;
+        int decimalPlaces = input.length() - indexOfDecimal - ZERO_INDEXING_OFFSET;
+        return decimalPlaces <= TWO_DECIMAL_PLACES;
     }
 
     /**

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -87,6 +87,14 @@ public abstract class Message {
             "Please enter a value up to 2 decimal places for monetary value(s).";
     public static final String ERROR_PARSER_COST_MORE_THAN_TWELVE_DIGITS_BEFORE_DP =
             "Please enter a value up to 12 digits in dollars for monetary value(s).";
+    public static final String ERROR_PARSER_NON_PERCENTAGE_ARGUMENT =
+            "Please enter a valid percentage value after the delimiter: ";
+    public static final String ERROR_PARSER_PERCENTAGE_NEGATIVE =
+            "Please enter a non-negative percentage value.";
+    public static final String ERROR_PARSER_PERCENTAGE_NOT_TWO_DP =
+            "Please enter a value up to 2 decimal places for percentage values.";
+    public static final String ERROR_PARSER_PERCENTAGE_MORE_THAN_THREE_DIGITS_BEFORE_DP =
+            "Please enter a value up to 3 digits before the decimal point for percentage values.";
     public static final String ERROR_PARSER_INVALID_GST_SURCHARGE =
             "Please enter a valid GST surcharge in % in the range [0, 100] after the delimiter: ";
     public static final String ERROR_PARSER_INVALID_SERVICE_CHARGE =

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -831,7 +831,7 @@ class ParserTest {
     
     // parseGst()
     /**
-     * Checks if an integer representing a GST percent value of 0 is properly returned 
+     * Checks if a double representing a GST percent value of 0 is properly returned 
      * when the GST delimiter is not provided by the user.
      */
     @Test
@@ -839,7 +839,7 @@ class ParserTest {
         String argumentWithoutGstDelimiter =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15";
         try {
-            int output = Parser.parseGst(argumentWithoutGstDelimiter);
+            double output = Parser.parseGst(argumentWithoutGstDelimiter);
             assertEquals(0, output);
         } catch (InvalidFormatException exception) {
             fail();
@@ -855,7 +855,7 @@ class ParserTest {
         String argumentWithoutGstArgument =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst /sc 10";
         try {
-            int output = Parser.parseGst(argumentWithoutGstArgument);
+            double output = Parser.parseGst(argumentWithoutGstArgument);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_MISSING_ARGUMENT + ParserUtils.GST_DELIMITER;
@@ -865,17 +865,17 @@ class ParserTest {
 
     /**
      * Checks if an exception is properly thrown when the GST delimiter is provided by the user but the 
-     * argument following the GST delimiter cannot be parsed as an integer.
+     * argument following the GST delimiter cannot be parsed as a double.
      */
     @Test
-    void parseGst_delimiterExistsArgumentNotInteger_exceptionThrown() {
-        String argumentWithNonIntegerArgument =
+    void parseGst_delimiterExistsArgumentNotDouble_exceptionThrown() {
+        String argumentWithNonDoubleArgument =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst apple /sc 10";
         try {
-            int output = Parser.parseGst(argumentWithNonIntegerArgument);
+            double output = Parser.parseGst(argumentWithNonDoubleArgument);
             fail();
         } catch (InvalidFormatException exception) {
-            String errorMessage = Message.ERROR_PARSER_NON_INTEGER_ARGUMENT + ParserUtils.GST_DELIMITER;
+            String errorMessage = Message.ERROR_PARSER_NON_PERCENTAGE_ARGUMENT + ParserUtils.GST_DELIMITER;
             assertEquals(errorMessage, exception.getMessage());
         }
     }
@@ -885,23 +885,34 @@ class ParserTest {
      * is provided by the user but the integer is not within the valid range of [0, 100].
      */
     @Test
-    void parseGst_delimiterExistsArgumentIntegerButNotInRange_exceptionThrown() {
+    void parseGst_delimiterExistsArgumentDoubleButNotInRange_exceptionThrown() {
         // Test values less than 0, negative values
-        String argumentWithIntegerArgumentUnderRange =
+        String argumentWithDoubleArgumentUnderRange =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst -1 /sc 10";
         try {
-            int output = Parser.parseGst(argumentWithIntegerArgumentUnderRange);
+            double output = Parser.parseGst(argumentWithDoubleArgumentUnderRange);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_PERCENTAGE_NEGATIVE;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+
+        // Test values greater than 100
+        String argumentWithDoubleArgumentAboveRange =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 101 /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithDoubleArgumentAboveRange);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_INVALID_GST_SURCHARGE + ParserUtils.GST_DELIMITER;
             assertEquals(errorMessage, exception.getMessage());
         }
-
-        // Test values greater than 100
-        String argumentWithIntegerArgumentAboveRange =
-                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 101 /sc 10";
+        
+        // Test double values near 100
+        String argumentWithDoubleArgumentNearRange =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 100.01 /sc 10";
         try {
-            int output = Parser.parseGst(argumentWithIntegerArgumentAboveRange);
+            double output = Parser.parseGst(argumentWithDoubleArgumentNearRange);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_INVALID_GST_SURCHARGE + ParserUtils.GST_DELIMITER;
@@ -910,16 +921,37 @@ class ParserTest {
     }
 
     /**
-     * Checks if an integer representing a GST percent value is properly returned when the GST delimiter and
-     * an argument with an integer value within the valid range of [0, 100] is provided by the user.
+     * Checks if a double representing a GST percent value is properly returned when the GST delimiter and
+     * an argument with a double value within the valid range of [0, 100] is provided by the user.
      */
     @Test
-    void parseGst_delimiterExistsArgumentIntegerWithinRange_gstPercentage() {
-        String argumentWithIntegerArgumentInRange =
+    void parseGst_delimiterExistsArgumentDoubleWithinRange_gstPercentage() {
+        // Test regular values
+        String argumentWithDoubleArgumentInRange =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7 /sc 10";
         try {
-            int output = Parser.parseGst(argumentWithIntegerArgumentInRange);
+            double output = Parser.parseGst(argumentWithDoubleArgumentInRange);
             assertEquals(7, output);
+        } catch (InvalidFormatException exception) {
+            fail();
+        }
+        
+        // Test minimum allowed value
+        String argumentWithMinPercentageArgument = 
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 0 /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithMinPercentageArgument);
+            assertEquals(Parser.MINIMUM_SURCHARGE_PERCENT, output);
+        } catch (InvalidFormatException exception) {
+            fail();
+        }
+        
+        // Test maximum allowed value
+        String argumentWithMaxPercentageArgument =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 100 /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithMaxPercentageArgument);
+            assertEquals(Parser.MAXIMUM_SURCHARGE_PERCENT, output);
         } catch (InvalidFormatException exception) {
             fail();
         }

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -881,8 +881,42 @@ class ParserTest {
     }
 
     /**
-     * Checks if an exception is properly thrown when the GST delimiter and an integer representing the GST 
-     * is provided by the user but the integer is not within the valid range of [0, 100].
+     * Checks if an exception is properly thrown when the GST delimiter and positive numeric value are
+     * provided as arguments, but the parsed double has more than three digits before decimal point.
+     */
+    @Test
+    void parseGst_delimiterExistsArgumentDoubleWithMoreThanThreeDigitsBeforeDecimalPoint_exceptionThrown() {
+        String argumentWithDoubleArgumentMoreThan3DigitsBeforeDP =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 1000 /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithDoubleArgumentMoreThan3DigitsBeforeDP);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_PERCENTAGE_MORE_THAN_THREE_DIGITS_BEFORE_DP;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+    }
+
+    /**
+     * Checks if an exception is properly thrown when the GST delimiter and positive numeric value are
+     * provided as arguments, but the parsed double has more than two decimal places.
+     */
+    @Test
+    void parseGst_delimiterExistsArgumentDoubleWithMoreThanTwoDecimalPlaces_exceptionThrown() {
+        String argumentWithDoubleArgumentMoreThan2DP =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 10.123 /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithDoubleArgumentMoreThan2DP);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_PERCENTAGE_NOT_TWO_DP;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+    }
+
+    /**
+     * Checks if an exception is properly thrown when the GST delimiter and a double representing the GST 
+     * percentage is provided by the user but the double is not within the valid range of [0, 100].
      */
     @Test
     void parseGst_delimiterExistsArgumentDoubleButNotInRange_exceptionThrown() {

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -1044,8 +1044,42 @@ class ParserTest {
     }
 
     /**
-     * Checks if an exception is properly thrown when the Service charge delimiter and an integer representing the
-     * service charge is provided by the user but the integer is not within the valid range of [0, 100].
+     * Checks if an exception is properly thrown when the Service charge delimiter and positive numeric value are
+     * provided as arguments, but the parsed double has more than three digits before decimal point.
+     */
+    @Test
+    void parseServiceCharge_delimiterExistsArgumentDoubleWithMoreThanThreeDigitsBeforeDecimalPoint_exceptionThrown() {
+        String argumentWithDoubleArgumentMoreThan3DigitsBeforeDP =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7 /sc 1000";
+        try {
+            double output = Parser.parseServiceCharge(argumentWithDoubleArgumentMoreThan3DigitsBeforeDP);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_PERCENTAGE_MORE_THAN_THREE_DIGITS_BEFORE_DP;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+    }
+
+    /**
+     * Checks if an exception is properly thrown when the Service charge delimiter and positive numeric value are
+     * provided as arguments, but the parsed double has more than two decimal places.
+     */
+    @Test
+    void parseServiceCharge_delimiterExistsArgumentDoubleWithMoreThanTwoDecimalPlaces_exceptionThrown() {
+        String argumentWithDoubleArgumentMoreThan2DP =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7 /sc 10.123";
+        try {
+            double output = Parser.parseServiceCharge(argumentWithDoubleArgumentMoreThan2DP);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_PERCENTAGE_NOT_TWO_DP;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+    }
+
+    /**
+     * Checks if an exception is properly thrown when the Service charge delimiter and a double representing the
+     * percentage service charge is provided by the user but the double is not within the valid range of [0, 100].
      */
     @Test
     void parseServiceCharge_delimiterExistsArgumentDoubleButNotInRange_exceptionThrown() {


### PR DESCRIPTION
Modify parseGst() and parseServiceCharge() in Parser class
Add supporting method in ParseUtils and ParseErrors class
Add new error messages in Message class
Update ActivityCreateCommand class to use double instead of int
Update JUnit tests and their JavaDoc comments for parseGst() and parseServiceCharge()
Add new JUnit tests to cater for new checks in parseGst() and parseServiceCharge()

Fixes #273