### PR TITLE
Fix bug in ActivityDeleteCommand

### DIFF
--- a/src/main/java/seedu/splitlah/data/Session.java
+++ b/src/main/java/seedu/splitlah/data/Session.java
@@ -204,11 +204,11 @@ public class Session implements Serializable, Comparable<Session> {
         ArrayList<Person> involvedPersonList = deleteTarget.getInvolvedPersonList();
         Person payer = deleteTarget.getPersonPaid();
         if (involvedPersonList != null) {
-            boolean payerInParticipantList = involvedPersonList.contains(payer);
+            boolean isPayerInParticipantList = involvedPersonList.contains(payer);
             for (Person person : involvedPersonList) {
                 person.removeActivityCost(activityId);
             }
-            if (!payerInParticipantList) {
+            if (!isPayerInParticipantList) {
                 payer.removeActivityCost(activityId);
             }
         }

--- a/src/main/java/seedu/splitlah/data/Session.java
+++ b/src/main/java/seedu/splitlah/data/Session.java
@@ -203,8 +203,12 @@ public class Session implements Serializable, Comparable<Session> {
 
         ArrayList<Person> involvedPersonList = deleteTarget.getInvolvedPersonList();
         if (involvedPersonList != null) {
+            boolean payerInParticipantList = involvedPersonList.contains(deleteTarget.getPersonPaid());
             for (Person person : involvedPersonList) {
                 person.removeActivityCost(activityId);
+            }
+            if (!payerInParticipantList) {
+                deleteTarget.getPersonPaid().removeActivityCost(activityId);
             }
         }
         activityList.remove(deleteTarget);

--- a/src/main/java/seedu/splitlah/data/Session.java
+++ b/src/main/java/seedu/splitlah/data/Session.java
@@ -202,13 +202,14 @@ public class Session implements Serializable, Comparable<Session> {
         }
 
         ArrayList<Person> involvedPersonList = deleteTarget.getInvolvedPersonList();
+        Person payer = deleteTarget.getPersonPaid();
         if (involvedPersonList != null) {
-            boolean payerInParticipantList = involvedPersonList.contains(deleteTarget.getPersonPaid());
+            boolean payerInParticipantList = involvedPersonList.contains(payer);
             for (Person person : involvedPersonList) {
                 person.removeActivityCost(activityId);
             }
             if (!payerInParticipantList) {
-                deleteTarget.getPersonPaid().removeActivityCost(activityId);
+                payer.removeActivityCost(activityId);
             }
         }
         activityList.remove(deleteTarget);


### PR DESCRIPTION
ActivityDeleteCommand was not removing ActivityCosts from the payer if
the payer was not part of the list of participants, resulting in
obsolete ActivityCosts remaining in the payer's Person object.
This fixes that by removing the appropriate ActivityCosts from the payer
if the payer is not included in the list of participants.

Fixes #393 