### PR TITLE
Bug Fixes for PED

### DIFF
--- a/src/main/java/seedu/splitlah/command/SessionCreateCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionCreateCommand.java
@@ -85,8 +85,6 @@ public class SessionCreateCommand extends Command {
             }
         }
 
-
-
         boolean isSessionExists = profile.hasSessionName(sessionName);
         if (isSessionExists) {
             ui.printlnMessage(Message.ERROR_PROFILE_DUPLICATE_SESSION);

--- a/src/main/java/seedu/splitlah/command/SessionCreateCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionCreateCommand.java
@@ -67,6 +67,11 @@ public class SessionCreateCommand extends Command {
                 return;
             }
             personList = new PersonList(personNames);
+            if (personNames.length != personList.getSize()) {
+                ui.printlnMessage(Message.ERROR_PERSONLIST_CONTAINS_INVALID_NAME);
+                Manager.getLogger().log(Level.FINEST,Message.LOGGER_PERSONLIST_INVALID_NAME_EXISTS_IN_CREATESESSION);
+                return;
+            }
         }
 
         Group group = null;
@@ -79,6 +84,8 @@ public class SessionCreateCommand extends Command {
                 return;
             }
         }
+
+
 
         boolean isSessionExists = profile.hasSessionName(sessionName);
         if (isSessionExists) {

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -90,6 +90,7 @@ public class SessionEditCommand extends Command {
             boolean hasSameSessionName = sessionName.equalsIgnoreCase(session.getSessionName());
             if (!hasSameSessionName && isSessionExists) {
                 ui.printlnMessage(Message.ERROR_PROFILE_DUPLICATE_SESSION);
+                Manager.getLogger().log(Level.FINEST,Message.LOGGER_SESSIONEDIT_DUPLICATE_NAMES_IN_SESSION_LIST);
                 return;
             }
             if (!hasSameSessionName) {

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -71,6 +71,11 @@ public class SessionEditCommand extends Command {
                 return;
             }
             newPersonList = new PersonList(personNames);
+            if (personNames.length != newPersonList.getSize()) {
+                ui.printlnMessage(Message.ERROR_PERSONLIST_CONTAINS_INVALID_NAME);
+                Manager.getLogger().log(Level.FINEST,Message.LOGGER_PERSONLIST_INVALID_NAME_EXISTS_IN_EDITSESSION);
+                return;
+            }
             if (!newPersonList.isSuperset(session.getPersonArrayList())) {
                 ui.printlnMessageWithDivider(Message.ERROR_SESSIONEDIT_INVALID_PERSONLIST);
                 return;

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -80,7 +80,7 @@ public class SessionEditCommand extends Command {
                 ui.printlnMessageWithDivider(Message.ERROR_SESSIONEDIT_INVALID_PERSONLIST);
                 return;
             }
-            if (!(session.getPersonList().isSuperset(newPersonList.getPersonList()))) {
+            if (!session.getPersonList().isSuperset(newPersonList.getPersonList())) {
                 isPersonNamesEdited = true;
             }
         }
@@ -98,7 +98,7 @@ public class SessionEditCommand extends Command {
         }
         boolean isSessionDateEdited = false;
         if (sessionDate != null) {
-            if (!(session.getDateCreated().equals(sessionDate))) {
+            if (!session.getDateCreated().equals(sessionDate)) {
                 session.setDateCreated(sessionDate);
                 isSessionDateEdited = true;
             }

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -75,7 +75,7 @@ public class SessionEditCommand extends Command {
                 ui.printlnMessageWithDivider(Message.ERROR_SESSIONEDIT_INVALID_PERSONLIST);
                 return;
             }
-            if (session.getPersonList().isSuperset(newPersonList.getPersonList())) {
+            if (!(session.getPersonList().isSuperset(newPersonList.getPersonList()))) {
                 isPersonNamesEdited = true;
             }
         }

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -22,7 +22,6 @@ public class SessionEditCommand extends Command {
     private static final String COMMAND_SUCCESS = "The session was edited successfully.";
     private static final String COMMAND_NO_EDITS_MADE = "The session was not edited.";
 
-
     private final int sessionId;
     private final String sessionName;
     private final String[] personNames;
@@ -76,8 +75,7 @@ public class SessionEditCommand extends Command {
                 ui.printlnMessageWithDivider(Message.ERROR_SESSIONEDIT_INVALID_PERSONLIST);
                 return;
             }
-            if (!(newPersonList.isSuperset(session.getPersonArrayList())
-                    && session.getPersonList().isSuperset(newPersonList.getPersonList()))) {
+            if (session.getPersonList().isSuperset(newPersonList.getPersonList())) {
                 isPersonNamesEdited = true;
             }
         }

--- a/src/main/java/seedu/splitlah/command/SessionEditCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionEditCommand.java
@@ -3,6 +3,7 @@ package seedu.splitlah.command;
 import seedu.splitlah.data.Manager;
 import seedu.splitlah.data.Person;
 import seedu.splitlah.data.PersonList;
+import seedu.splitlah.data.Profile;
 import seedu.splitlah.data.Session;
 import seedu.splitlah.exceptions.InvalidDataException;
 import seedu.splitlah.ui.Message;
@@ -19,6 +20,8 @@ import java.util.logging.Level;
 public class SessionEditCommand extends Command {
 
     private static final String COMMAND_SUCCESS = "The session was edited successfully.";
+    private static final String COMMAND_NO_EDITS_MADE = "The session was not edited.";
+
 
     private final int sessionId;
     private final String sessionName;
@@ -49,16 +52,18 @@ public class SessionEditCommand extends Command {
     @Override
     public void run(Manager manager) {
         TextUI ui = manager.getUi();
+        Profile profile = manager.getProfile();
         Session session;
         try {
-            session = manager.getProfile().getSession(sessionId);
+            session = profile.getSession(sessionId);
         } catch (InvalidDataException invalidDataException) {
             ui.printlnMessageWithDivider(invalidDataException.getMessage());
             Manager.getLogger().log(Level.FINEST, Message.LOGGER_PROFILE_SESSION_NOT_IN_LIST);
             return;
         }
         assert session != null : Message.ASSERT_SESSIONEDIT_SESSION_IS_NULL;
-
+        PersonList newPersonList = null;
+        boolean isPersonNamesEdited = false;
         if (personNames != null) {
             boolean hasDuplicates = PersonList.hasNameDuplicates(personNames);
             if (hasDuplicates) {
@@ -66,24 +71,49 @@ public class SessionEditCommand extends Command {
                 Manager.getLogger().log(Level.FINEST, Message.LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_EDITSESSION);
                 return;
             }
-            PersonList newPersonList = new PersonList(personNames);
-            if (!newPersonList.isSuperset(session.getPersonList())) {
+            newPersonList = new PersonList(personNames);
+            if (!newPersonList.isSuperset(session.getPersonArrayList())) {
                 ui.printlnMessageWithDivider(Message.ERROR_SESSIONEDIT_INVALID_PERSONLIST);
                 return;
-            } else {
-                for (Person person : newPersonList.getPersonList()) {
-                    session.addPerson(person);
-                }
+            }
+            if (!(newPersonList.isSuperset(session.getPersonArrayList())
+                    && session.getPersonList().isSuperset(newPersonList.getPersonList()))) {
+                isPersonNamesEdited = true;
             }
         }
+        boolean isSessionNameEdited = false;
         if (sessionName != null) {
+            boolean isSessionExists = profile.hasSessionName(sessionName);
+            boolean hasSameSessionName = sessionName.equalsIgnoreCase(session.getSessionName());
+            if (!hasSameSessionName && isSessionExists) {
+                ui.printlnMessage(Message.ERROR_PROFILE_DUPLICATE_SESSION);
+                return;
+            }
+            if (!hasSameSessionName) {
+                isSessionNameEdited = true;
+            }
+        }
+        boolean isSessionDateEdited = false;
+        if (sessionDate != null) {
+            if (!(session.getDateCreated().equals(sessionDate))) {
+                session.setDateCreated(sessionDate);
+                isSessionDateEdited = true;
+            }
+        }
+        if (isPersonNamesEdited) {
+            for (Person person : newPersonList.getPersonList()) {
+                session.addPerson(person);
+            }
+        }
+        if (isSessionNameEdited) {
             session.setSessionName(sessionName);
         }
-        if (sessionDate != null) {
-            session.setDateCreated(sessionDate);
-        }
         manager.saveProfile();
-        ui.printlnMessageWithDivider(COMMAND_SUCCESS + "\n" + session);
+        if (isPersonNamesEdited || isSessionNameEdited || isSessionDateEdited) {
+            ui.printlnMessageWithDivider(COMMAND_SUCCESS + "\n" + session);
+        } else {
+            ui.printlnMessageWithDivider(COMMAND_NO_EDITS_MADE);
+        }
         Manager.getLogger().log(Level.FINEST, Message.LOGGER_SESSIONEDIT_SESSION_EDITED);
     }
 }

--- a/src/main/java/seedu/splitlah/command/SessionSummaryCommand.java
+++ b/src/main/java/seedu/splitlah/command/SessionSummaryCommand.java
@@ -216,7 +216,7 @@ public class SessionSummaryCommand extends Command {
             return;
         }
 
-        ArrayList<Person> personList = session.getPersonList();
+        ArrayList<Person> personList = session.getPersonArrayList();
         ArrayList<PersonCostPair> personCostPairList = getPersonCostPairList(personList);
         String output = processAllTransactions(personCostPairList, session);
         ui.printlnMessageWithDivider(output);

--- a/src/main/java/seedu/splitlah/data/Profile.java
+++ b/src/main/java/seedu/splitlah/data/Profile.java
@@ -146,7 +146,7 @@ public class Profile implements Serializable {
             String id = Integer.toString(session.getSessionId());
             String name = session.getSessionName();
             String date = session.getDateCreated().format(ParserUtils.DATE_FORMAT);
-            String numParticipants = Integer.toString(session.getPersonList().size());
+            String numParticipants = Integer.toString(session.getPersonArrayList().size());
             String numActivities = Integer.toString(session.getActivityList().size());
             summaryTable.addRow(id, name, date, numParticipants, numActivities);
         }

--- a/src/main/java/seedu/splitlah/data/Profile.java
+++ b/src/main/java/seedu/splitlah/data/Profile.java
@@ -230,7 +230,8 @@ public class Profile implements Serializable {
     public void removeGroup(int groupId) throws InvalidDataException {
         Group groupToBeRemoved = getGroup(groupId);
         for (Session session : sessionList) {
-            if (session.getGroup().getGroupId() == groupId) {
+            Group groupToCheck = session.getGroup();
+            if (groupToCheck != null && groupToCheck.getGroupId() == groupId) {
                 session.setGroup(null);
             }
         }

--- a/src/main/java/seedu/splitlah/data/Session.java
+++ b/src/main/java/seedu/splitlah/data/Session.java
@@ -95,8 +95,12 @@ public class Session implements Serializable, Comparable<Session> {
      *
      * @return An ArrayList object containing Person objects that are part of the session.
      */
-    public ArrayList<Person> getPersonList() {
+    public ArrayList<Person> getPersonArrayList() {
         return personList.getPersonList();
+    }
+
+    public PersonList getPersonList() {
+        return personList;
     }
 
     /**

--- a/src/main/java/seedu/splitlah/parser/commandparser/SessionCreateCommandParser.java
+++ b/src/main/java/seedu/splitlah/parser/commandparser/SessionCreateCommandParser.java
@@ -18,8 +18,7 @@ public class SessionCreateCommandParser implements CommandParser<SessionCreateCo
     public static final String COMMAND_TEXT = "session /create";
 
     public static final String COMMAND_FORMAT =
-            "Syntax: session /create /n [SESSION_NAME] /d [SESSION_DATE] /pl [NAME1 NAME2...] "
-                    + "[</gid [GROUP_ID]>]";
+            "Syntax: session /create /n [SESSION_NAME] /d [SESSION_DATE] {/pl [NAME1 NAME2...] /gid [GROUP_ID]}";
 
     public static final String[] COMMAND_DELIMITERS = {
         ParserUtils.NAME_DELIMITER,

--- a/src/main/java/seedu/splitlah/parser/commandparser/SessionEditCommandParser.java
+++ b/src/main/java/seedu/splitlah/parser/commandparser/SessionEditCommandParser.java
@@ -18,8 +18,7 @@ public class SessionEditCommandParser implements CommandParser<SessionEditComman
     public static final String COMMAND_TEXT = "session /edit";
 
     public static final String COMMAND_FORMAT =
-            "Syntax: session /edit /sid [SESSION_ID] [</n [SESSION_NAME]>] [</d [SESSION_DATE]>] "
-                   + "[</pl [NAME1 NAME2...]>]";
+            "Syntax: session /edit /sid [SESSION_ID] {</n [SESSION_NAME] /d [SESSION_DATE] /pl [NAME1 NAME2...]}";
 
     public static final String[] COMMAND_DELIMITERS = {
         ParserUtils.SESSION_ID_DELIMITER,

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -175,10 +175,10 @@ public abstract class Message {
     public static final String ASSERT_PERSONLIST_NAME_DUPLICATE_EXISTS_BUT_NOT_DETECTED =
             "Name duplicates exist but not detected.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_CREATESESSION =
-            "An Session object failed to be added into the list of sessions because there are duplicate names in"
+            "A Session object failed to be added into the list of sessions because there are duplicate names in"
                     + "the person list.";
     public static final String LOGGER_PERSONLIST_INVALID_NAME_EXISTS_IN_CREATESESSION =
-            "An Session object failed to be added into the list of sessions because there are names in"
+            "A Session object failed to be added into the list of sessions because there are invalid names in"
                     + "the person list.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_CREATEGROUP =
             "A Group object failed to be added into the list of groups because there are duplicate names in"
@@ -187,7 +187,7 @@ public abstract class Message {
             "An Activity object failed to be added into the list of activities because there are duplicate names in"
                     + "the involved list.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_EDITSESSION =
-            "An Session object failed to be added into the list of sessions because there are duplicate names in"
+            "A Session object failed to be added into the list of sessions because there are duplicate names in"
                     + "the person list.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_EDITGROUP =
             "A Group object failed to be added into the list of groups because there are duplicate names in"

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -295,6 +295,9 @@ public abstract class Message {
             "The session is null.";
     public static final String ASSERT_SESSIONEDIT_SESSION_ID_INVALID =
             "Session ID is less than or equals to zero.";
+    public static final String LOGGER_SESSIONEDIT_DUPLICATE_NAMES_IN_SESSION_LIST =
+            "A Session object failed to be edited because there are duplicate names in"
+                    + "the session list.";
 
     // Session Summary Command
     public static final String MESSAGE_SESSIONSUMMARY_NO_PAYMENTS_REQUIRED =

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -186,6 +186,9 @@ public abstract class Message {
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_CREATEACTIVITY =
             "An Activity object failed to be added into the list of activities because there are duplicate names in"
                     + "the involved list.";
+    public static final String LOGGER_PERSONLIST_INVALID_NAME_EXISTS_IN_EDITSESSION =
+            "A Session object failed to be edited because there are invalid names in"
+                    + "the person list.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_EDITSESSION =
             "A Session object failed to be added into the list of sessions because there are duplicate names in"
                     + "the person list.";

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -164,8 +164,7 @@ public abstract class Message {
             "There are duplicate names in the person list for the session you are trying to create. "
                     + "Please rectify and try again.";
     public static final String ERROR_PERSONLIST_CONTAINS_INVALID_NAME =
-            "There are invalid names in the person list for the session you are trying to create. "
-                    + "Please rectify and try again.";
+            "Names in the person list should only contain alphabets. Please rectify and try again.";
     public static final String ERROR_PERSONLIST_DUPLICATE_NAME_IN_GROUP =
             "There are duplicate names in the person list for the group you are trying to create. "
                     + "Please rectify and try again.";

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -163,6 +163,9 @@ public abstract class Message {
     public static final String ERROR_PERSONLIST_DUPLICATE_NAME_IN_SESSION =
             "There are duplicate names in the person list for the session you are trying to create. "
                     + "Please rectify and try again.";
+    public static final String ERROR_PERSONLIST_CONTAINS_INVALID_NAME =
+            "There are invalid names in the person list for the session you are trying to create. "
+                    + "Please rectify and try again.";
     public static final String ERROR_PERSONLIST_DUPLICATE_NAME_IN_GROUP =
             "There are duplicate names in the person list for the group you are trying to create. "
                     + "Please rectify and try again.";
@@ -173,6 +176,9 @@ public abstract class Message {
             "Name duplicates exist but not detected.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_CREATESESSION =
             "An Session object failed to be added into the list of sessions because there are duplicate names in"
+                    + "the person list.";
+    public static final String LOGGER_PERSONLIST_INVALID_NAME_EXISTS_IN_CREATESESSION =
+            "An Session object failed to be added into the list of sessions because there are names in"
                     + "the person list.";
     public static final String LOGGER_PERSONLIST_NAME_DUPLICATE_EXISTS_IN_CREATEGROUP =
             "A Group object failed to be added into the list of groups because there are duplicate names in"

--- a/src/test/java/seedu/splitlah/command/SessionCreateCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionCreateCommandTest.java
@@ -101,7 +101,7 @@ class SessionCreateCommandTest {
         String userInput = "session /create /n Class gathering /d 15-02-2022 /pl Charlie /gid 1";
         Command command = Parser.getCommand(userInput);
         command.run(manager);
-        int sizeOfPersonList = manager.getProfile().getSession(3).getPersonList().size();
+        int sizeOfPersonList = manager.getProfile().getSession(3).getPersonArrayList().size();
         assertEquals(3, sizeOfPersonList);
     }
 
@@ -115,7 +115,7 @@ class SessionCreateCommandTest {
         String userInput = "session /create /n Class gathering /d 15-02-2022 /pl alice Charlie /gid 1";
         Command command = Parser.getCommand(userInput);
         command.run(manager);
-        int sizeOfPersonList = manager.getProfile().getSession(3).getPersonList().size();
+        int sizeOfPersonList = manager.getProfile().getSession(3).getPersonArrayList().size();
         assertEquals(3, sizeOfPersonList);
     }
 

--- a/src/test/java/seedu/splitlah/command/SessionCreateCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionCreateCommandTest.java
@@ -120,6 +120,18 @@ class SessionCreateCommandTest {
     }
 
     /**
+     * Checks if session is created with invalid person names.
+     */
+    @Test
+    public void run_hasInvalidPersonName_sessionListSizeRemainsTwo() {
+        String userInput = "session /create /n Class gathering /d 15-02-2022 /pl alice Xae1vr charlie";
+        Command command = Parser.getCommand(userInput);
+        command.run(manager);
+
+        assertEquals(2, manager.getProfile().getSessionList().size());
+    }
+
+    /**
      * Checks if session is created with duplicated person names.
      */
     @Test

--- a/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
@@ -12,6 +12,7 @@ import seedu.splitlah.parser.ParserUtils;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class SessionEditCommandTest {
 
@@ -19,11 +20,11 @@ public class SessionEditCommandTest {
 
     private static final String ORIGINAL_SESSION_NAME = "Class outing";
     private static final String ORIGINAL_SESSION_DATE = "15-02-2022";
-    private static final int ORIGINAL_SESSION_PERSONLIST_SIZE = 2;
+    private static final int ORIGINAL_SESSION_PERSON_LIST_SIZE = 2;
 
     private static final String EDITED_SESSION_NAME = "Class gathering";
     private static final String EDITED_SESSION_DATE = "17-02-2022";
-    private static final int EDITED_SESSION_PERSONLIST_SIZE = 3;
+    private static final int EDITED_SESSION_PERSON_LIST_SIZE = 3;
 
     /**
      * Creates a session that is stored and managed by the Manager object.
@@ -58,7 +59,7 @@ public class SessionEditCommandTest {
 
         assertEquals(EDITED_SESSION_NAME, newNameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 
     /**
@@ -83,7 +84,7 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(EDITED_SESSION_DATE, newDateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 
     /**
@@ -115,7 +116,7 @@ public class SessionEditCommandTest {
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
 
         // Checks if newly edited person list in session has size of 3.
-        assertEquals(EDITED_SESSION_PERSONLIST_SIZE, editedSession.getPersonArrayList().size());
+        assertEquals(EDITED_SESSION_PERSON_LIST_SIZE, editedSession.getPersonArrayList().size());
 
         // Check if Person objects in session before edit is still in session after edit
         originalPersonList.removeAll(editedSession.getPersonArrayList());
@@ -142,7 +143,7 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
 
         // Case2: Same session date.
         String validInputWithSameSessionDate = "session /edit /sid 1 /d 15-02-2022";
@@ -155,7 +156,7 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
 
         // Case3: Same person names.
         String validInputWithSamePersonNames = "session /edit /sid 1 /p Alice Bob";
@@ -168,7 +169,20 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
+
+        // Case4: All editable fields remain the same.
+        String validInputWithAllSameFields = "session /edit /sid /n Class outing /d 15-02-2022 /pl Alice Bob";
+        Command commandWithAllSameFields = Parser.getCommand(validInputWithAllSameFields);
+        commandWithAllSameFields.run(manager);
+        unEditedSession = manager.getProfile().getSession(1);
+        nameInSession = unEditedSession.getSessionName();
+        dateInSession = unEditedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        personListSizeInSession = unEditedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 
     /**
@@ -194,7 +208,7 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 
     /**
@@ -220,7 +234,7 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 
     /**
@@ -244,7 +258,33 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
+    }
+
+    /**
+     * Checks if session is not edited when there were invalid names in Person list delimiter.
+     *
+     * @throws InvalidDataException If there are no sessions stored or
+     *                              if the session unique identifier specified was not found.
+     */
+    @Test
+    public void run_hasOneInvalidName_sessionRemainsUnedited() throws InvalidDataException {
+        String invalidInput  = "session /edit /sid 1 /pl Alice Bob Charlie Xae4";
+        Command command = Parser.getCommand(invalidInput);
+
+        // Check if a SessionEditCommand instance was returned.
+        assertEquals(SessionEditCommand.class, command.getClass());
+        command.run(manager);
+        Session editedSession = manager.getProfile().getSession(1);
+        String nameInSession = editedSession.getSessionName();
+        String dateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
+        // Charlie should not be added to the list of persons
+        assertFalse(editedSession.getPersonArrayList().contains(Person.createPersonFromString("Charlie")));
     }
 
     /**
@@ -269,6 +309,6 @@ public class SessionEditCommandTest {
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
-        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+        assertEquals(ORIGINAL_SESSION_PERSON_LIST_SIZE, personListSizeInSession);
     }
 }

--- a/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
@@ -123,6 +123,55 @@ public class SessionEditCommandTest {
     }
 
     /**
+     * Checks if session is not edited when supplied with same session information.
+     *
+     * @throws InvalidDataException If there are no sessions stored or
+     *                              if the session unique identifier specified was not found.
+     */
+    @Test
+    public void run_validCommandWithNoEdits_sessionRemainsUnedited() throws InvalidDataException {
+        // Case1: Same session name.
+        String validInputWithSameSessionName = "session /edit /sid 1 /n Class outing";
+        Command commandWithSameSessionName = Parser.getCommand(validInputWithSameSessionName);
+        commandWithSameSessionName.run(manager);
+
+        Session unEditedSession = manager.getProfile().getSession(1);
+        String nameInSession = unEditedSession.getSessionName();
+        String dateInSession = unEditedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        int personListSizeInSession = unEditedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+
+        // Case2: Same session date.
+        String validInputWithSameSessionDate = "session /edit /sid 1 /d 15-02-2022";
+        Command commandWithSameSessionDate = Parser.getCommand(validInputWithSameSessionName);
+        commandWithSameSessionDate.run(manager);
+        unEditedSession = manager.getProfile().getSession(1);
+        nameInSession = unEditedSession.getSessionName();
+        dateInSession = unEditedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        personListSizeInSession = unEditedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+
+        // Case3: Same person names.
+        String validInputWithSamePersonNames = "session /edit /sid 1 /p Alice Bob";
+        Command commandWithSamePersonNames = Parser.getCommand(validInputWithSamePersonNames);
+        commandWithSamePersonNames.run(manager);
+        unEditedSession = manager.getProfile().getSession(1);
+        nameInSession = unEditedSession.getSessionName();
+        dateInSession = unEditedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        personListSizeInSession = unEditedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+    }
+
+    /**
      * Checks if session is not edited when list of persons provided after Person list delimiter
      * does not contain all persons that were originally in the session.
      *

--- a/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
@@ -172,6 +172,32 @@ public class SessionEditCommandTest {
     }
 
     /**
+     * Checks if session is not edited when supplied with a new session name that exists within the list of sessions.
+     *
+     * @throws InvalidDataException If there are no sessions stored or
+     *                              if the session unique identifier specified was not found.
+     */
+    @Test
+    public void run_invalidSessionNameDuplicate_sessionRemainsUnedited() throws InvalidDataException {
+        String newSession = "session /create /n Class Gathering /d 15-02-2022 /pl Alice Bob Charlie";
+        Command createSession = Parser.getCommand(newSession);
+        createSession.run(manager);
+
+        String validInputWithDuplicateSessionName = "session /edit /sid 1 /n Class Gathering";
+        Command commandWithSameSessionName = Parser.getCommand(validInputWithDuplicateSessionName);
+        commandWithSameSessionName.run(manager);
+
+        Session unEditedSession = manager.getProfile().getSession(1);
+        String nameInSession = unEditedSession.getSessionName();
+        String dateInSession = unEditedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
+        int personListSizeInSession = unEditedSession.getPersonArrayList().size();
+
+        assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
+        assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
+        assertEquals(ORIGINAL_SESSION_PERSONLIST_SIZE, personListSizeInSession);
+    }
+
+    /**
      * Checks if session is not edited when list of persons provided after Person list delimiter
      * does not contain all persons that were originally in the session.
      *

--- a/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
@@ -146,7 +146,7 @@ public class SessionEditCommandTest {
 
         // Case2: Same session date.
         String validInputWithSameSessionDate = "session /edit /sid 1 /d 15-02-2022";
-        Command commandWithSameSessionDate = Parser.getCommand(validInputWithSameSessionName);
+        Command commandWithSameSessionDate = Parser.getCommand(validInputWithSameSessionDate);
         commandWithSameSessionDate.run(manager);
         unEditedSession = manager.getProfile().getSession(1);
         nameInSession = unEditedSession.getSessionName();

--- a/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
+++ b/src/test/java/seedu/splitlah/command/SessionEditCommandTest.java
@@ -54,7 +54,7 @@ public class SessionEditCommandTest {
 
         String newNameInSession = editedSession.getSessionName();
         String dateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
-        int personListSizeInSession = editedSession.getPersonList().size();
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
 
         assertEquals(EDITED_SESSION_NAME, newNameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
@@ -79,7 +79,7 @@ public class SessionEditCommandTest {
         Session editedSession = manager.getProfile().getSession(1);
         String nameInSession = editedSession.getSessionName();
         String newDateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
-        int personListSizeInSession = editedSession.getPersonList().size();
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(EDITED_SESSION_DATE, newDateInSession);
@@ -115,10 +115,10 @@ public class SessionEditCommandTest {
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
 
         // Checks if newly edited person list in session has size of 3.
-        assertEquals(EDITED_SESSION_PERSONLIST_SIZE, editedSession.getPersonList().size());
+        assertEquals(EDITED_SESSION_PERSONLIST_SIZE, editedSession.getPersonArrayList().size());
 
         // Check if Person objects in session before edit is still in session after edit
-        originalPersonList.removeAll(editedSession.getPersonList());
+        originalPersonList.removeAll(editedSession.getPersonArrayList());
         assertEquals(0, originalPersonList.size());
     }
 
@@ -141,7 +141,7 @@ public class SessionEditCommandTest {
         Session editedSession = manager.getProfile().getSession(1);
         String nameInSession = editedSession.getSessionName();
         String dateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
-        int personListSizeInSession = editedSession.getPersonList().size();
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
@@ -165,7 +165,7 @@ public class SessionEditCommandTest {
         Session editedSession = manager.getProfile().getSession(1);
         String nameInSession = editedSession.getSessionName();
         String dateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
-        int personListSizeInSession = editedSession.getPersonList().size();
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);
@@ -190,7 +190,7 @@ public class SessionEditCommandTest {
         Session editedSession = manager.getProfile().getSession(1);
         String nameInSession = editedSession.getSessionName();
         String dateInSession = editedSession.getDateCreated().format(ParserUtils.DATE_FORMAT);
-        int personListSizeInSession = editedSession.getPersonList().size();
+        int personListSizeInSession = editedSession.getPersonArrayList().size();
 
         assertEquals(ORIGINAL_SESSION_NAME, nameInSession);
         assertEquals(ORIGINAL_SESSION_DATE, dateInSession);

--- a/src/test/java/seedu/splitlah/data/SessionTest.java
+++ b/src/test/java/seedu/splitlah/data/SessionTest.java
@@ -227,7 +227,7 @@ class SessionTest {
         }
 
         // Check if ActivityCost objects still exists (Payer is involved)
-        ArrayList<Person> personList = sessionOne.getPersonList();
+        ArrayList<Person> personList = sessionOne.getPersonArrayList();
         for (Person person : personList) {
             try {
                 person.removeActivityCost(TEST_ACTIVITY_ONE);
@@ -267,7 +267,7 @@ class SessionTest {
         }
 
         // Check if ActivityCost objects still exists (Payer is not involved)
-        ArrayList<Person> personList = sessionOne.getPersonList();
+        ArrayList<Person> personList = sessionOne.getPersonArrayList();
         for (Person person : personList) {
             try {
                 person.removeActivityCost(TEST_ACTIVITY_TWO);

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -17,7 +17,7 @@ Welcome to Splitlah!
 Please enter a valid command.
 > Invalid command
 The person list or group identifier delimiters are missing.
-Syntax: session /create /n [SESSION_NAME] /d [SESSION_DATE] /pl [NAME1 NAME2...] [</gid [GROUP_ID]>]
+Syntax: session /create /n [SESSION_NAME] /d [SESSION_DATE] {/pl [NAME1 NAME2...] /gid [GROUP_ID]}
 > The session was created successfully.
 Session Id #1 --
 Name: Class outing 1


### PR DESCRIPTION
Fixes #410
Added more layers of checks to ensure that if any fields contains invalid arguments, session is not edited.

Fixes #406
Added an additional layer of checking to ensure that the group retrieved is not null when trying to remove.

Fixes #422
Added an additional layer of checking to check if supplied person list has any invalid names. If any names were considered to be invalid, the session would not be created and an error message will be printed.

Fixes #409
Added additional checks to see if session was edited. If any of the editable fields in the command was found to be edited, a success edit message is sent. If all the supplied arguments contain the same information as before, a "no edits has been made" will be printed.