### PR TITLE
Bug fixes for PED in parsing numeric values

### DIFF
--- a/src/main/java/seedu/splitlah/command/ActivityDeleteCommand.java
+++ b/src/main/java/seedu/splitlah/command/ActivityDeleteCommand.java
@@ -36,7 +36,7 @@ public class ActivityDeleteCommand extends Command {
     /**
      * Runs the command to delete an Activity object from the list of activities in a Session object
      * managed by the Profile object.
-     * Gets the Session object using a unique session identifier.
+     * Gets the Session object using a session unique identifier.
      * Requests for confirmation from user to delete the Activity object.
      * If user confirms, proceeds to remove activity from a Session object,
      * the command aborts otherwise.

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -48,6 +48,7 @@ public class ParserUtils {
     private static final int PERCENTAGE_ALLOWED_INTEGER_PLACES = 3;
     private static final int TWO_DECIMAL_PLACES = 2;
     static final String REGEX_WHITESPACES_DELIMITER = "\\s+";
+    private static final String REGEX_NUMERIC_VALUE = "[0-9.-]+";
     static final int INVALID_INDEX_INDICATOR = -1;
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
@@ -125,6 +126,15 @@ public class ParserUtils {
         return idVal;
     }
 
+    private static double parseDoubleFromString(String input) throws NumberFormatException {
+        assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
+        
+        if (!input.matches(REGEX_NUMERIC_VALUE)) {
+            throw new NumberFormatException();
+        }
+        return Double.parseDouble(input);
+    }
+
     /**
      * Checks if the given String object representing a real number has at most two decimal places.
      * 
@@ -137,7 +147,7 @@ public class ParserUtils {
         assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
         
         try {
-            double value = Double.parseDouble(input);
+            double value = parseDoubleFromString(input);
         } catch (NumberFormatException exception) {
             return false;
         }
@@ -166,7 +176,7 @@ public class ParserUtils {
         assert places >= 0 : Message.ASSERT_PARSER_PLACES_NEGATIVE;
         
         try {
-            double value = Double.parseDouble(input);
+            double value = parseDoubleFromString(input);
         } catch (NumberFormatException exception) {
             return false;
         }
@@ -211,7 +221,7 @@ public class ParserUtils {
         
         double cost;
         try {
-            cost = Double.parseDouble(input);
+            cost = parseDoubleFromString(input);
         } catch (NumberFormatException exception) {
             throw new InvalidFormatException(ParserErrors.getNonMonetaryErrorMessage(delimiter));
         }
@@ -248,7 +258,7 @@ public class ParserUtils {
 
         double percentage;
         try {
-            percentage = Double.parseDouble(input);
+            percentage = parseDoubleFromString(input);
         } catch (NumberFormatException exception) {
             throw new InvalidFormatException(ParserErrors.getNonPercentageErrorMessage(delimiter));
         }

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -126,6 +126,15 @@ public class ParserUtils {
         return idVal;
     }
 
+    /**
+     * Returns a double represented by the provided input String object.
+     * 
+     * @param input A String object that represents a numeric value.
+     * @return A double represented by the input String object.
+     * @throws NumberFormatException If the provided input String object contains characters that are either
+     *                               non-numeric, not a decimal point or not a negative sign, or
+     *                               if the provided input String object cannot be parsed as a double.
+     */
     private static double parseDoubleFromString(String input) throws NumberFormatException {
         assert input != null : Message.ASSERT_PARSER_TOKEN_INPUT_NULL;
         

--- a/src/main/java/seedu/splitlah/parser/ParserUtils.java
+++ b/src/main/java/seedu/splitlah/parser/ParserUtils.java
@@ -49,6 +49,7 @@ public class ParserUtils {
     private static final int TWO_DECIMAL_PLACES = 2;
     static final String REGEX_WHITESPACES_DELIMITER = "\\s+";
     private static final String REGEX_NUMERIC_VALUE = "[0-9.-]+";
+    private static final String REGEX_PRINTABLE_ASCII_ONLY = "\\A[ -~]*\\z";
     static final int INVALID_INDEX_INDICATOR = -1;
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
@@ -577,6 +578,11 @@ public class ParserUtils {
         if (!isValidCommandType(commandType)) {
             return Message.ERROR_PARSER_INVALID_COMMAND;
         }
+        
+        if (!commandType.matches(REGEX_PRINTABLE_ASCII_ONLY) || !remainingArgs.matches(REGEX_PRINTABLE_ASCII_ONLY)) {
+            return Message.ERROR_PARSER_NON_ASCII_ARGUMENT;
+        }
+        
         return checkIfArgumentsValidForCommand(commandType, remainingArgs);
     }
 }

--- a/src/main/java/seedu/splitlah/ui/Message.java
+++ b/src/main/java/seedu/splitlah/ui/Message.java
@@ -92,6 +92,8 @@ public abstract class Message {
             "Please include the following delimiter in your input: ";
     public static final String ERROR_PARSER_MISSING_ARGUMENT =
             "Please include an argument after the following delimiter: ";
+    public static final String ERROR_PARSER_NON_ASCII_ARGUMENT =
+            "Only ASCII inputs are accepted by SplitLah.";
     public static final String ERROR_PARSER_MORE_THAN_ONE_PAYER =
             "The activity should only have a single payer. Please rectify and try again.";
     public static final String ERROR_PARSER_NON_INTEGER_ARGUMENT =

--- a/src/test/java/seedu/splitlah/data/ActivityTest.java
+++ b/src/test/java/seedu/splitlah/data/ActivityTest.java
@@ -63,8 +63,8 @@ class ActivityTest {
     }
 
     /**
-     * Checks if a negative integer is returned when an Activity object with a smaller unique activity identifier
-     * is compared against an Activity object with a larger unique activity identifier.
+     * Checks if a negative integer is returned when an Activity object with a smaller activity unique identifier
+     * is compared against an Activity object with a larger activity unique identifier.
      */
     @Test
     void compareTo_smallerActivityIdInput_returnsNegative() {
@@ -73,8 +73,8 @@ class ActivityTest {
     }
 
     /**
-     * Checks if a positive integer is returned when an Activity object with a smaller unique activity identifier
-     * is compared against an Activity object with a larger unique activity identifier.
+     * Checks if a positive integer is returned when an Activity object with a smaller activity unique identifier
+     * is compared against an Activity object with a larger activity unique identifier.
      */
     @Test
     void compareTo_smallerActivityIdInput_returnsPositive() {

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -696,9 +696,20 @@ class ParserTest {
      */
     @Test
     void parseTotalCost_delimiterExistsArgumentNotNumeric_InvalidFormatExceptionThrown() {
+        // Standard non-numerics
         String argumentWithNonNumericArgument = "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co apple";
         try {
             double output = Parser.parseTotalCost(argumentWithNonNumericArgument);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_NON_MONETARY_VALUE_ARGUMENT + ParserUtils.TOTAL_COST_DELIMITER;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+        
+        // Double.parseDouble reserved characters
+        String argumentWithReservedCharacters = "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 7.5d";
+        try {
+            double output = Parser.parseTotalCost(argumentWithReservedCharacters);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_NON_MONETARY_VALUE_ARGUMENT + ParserUtils.TOTAL_COST_DELIMITER;
@@ -833,9 +844,20 @@ class ParserTest {
      */
     @Test
     void parseCostList_delimiterExistsArgumentsNotNumeric_InvalidFormatExceptionThrown() {
+        // Standard non-numerics
         String argumentWithNonNumericArguments = "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /cl apple orange";
         try {
             double[] output = Parser.parseCostList(argumentWithNonNumericArguments);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_NON_MONETARY_VALUE_ARGUMENT + ParserUtils.COST_LIST_DELIMITER;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+
+        // Double.parseDouble reserved characters
+        String argumentWithReservedCharacters = "/sid 3 /n Lunch /p Alice /i Alice Bob /cl 3.5 7.0d";
+        try {
+            double[] output = Parser.parseCostList(argumentWithReservedCharacters);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_NON_MONETARY_VALUE_ARGUMENT + ParserUtils.COST_LIST_DELIMITER;
@@ -951,14 +973,26 @@ class ParserTest {
 
     /**
      * Checks if an InvalidFormatException with the correct message is properly thrown when the GST delimiter
-     * is provided by the user but the argument following the GST delimiter cannot be parsed as a double.
+     * is provided by the user but the argument following the GST delimiter is non-numeric.
      */
     @Test
-    void parseGst_delimiterExistsArgumentNotDouble_InvalidFormatExceptionThrown() {
+    void parseGst_delimiterExistsArgumentNotNumeric_InvalidFormatExceptionThrown() {
+        // Standard non-numerics
         String argumentWithNonDoubleArgument =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst apple /sc 10";
         try {
             double output = Parser.parseGst(argumentWithNonDoubleArgument);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage = Message.ERROR_PARSER_NON_PERCENTAGE_ARGUMENT + ParserUtils.GST_DELIMITER;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+
+        // Double.parseDouble reserved characters
+        String argumentWithReservedCharacters =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7.0d /sc 10";
+        try {
+            double output = Parser.parseGst(argumentWithReservedCharacters);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage = Message.ERROR_PARSER_NON_PERCENTAGE_ARGUMENT + ParserUtils.GST_DELIMITER;
@@ -1115,14 +1149,27 @@ class ParserTest {
 
     /**
      * Checks if an InvalidFormatException with the correct message is properly thrown when the Service charge delimiter
-     * is provided by the user but the argument following the Service charge delimiter cannot be parsed as a double.
+     * is provided by the user but the argument following the Service charge delimiter is non-numeric.
      */
     @Test
-    void parseServiceCharge_delimiterExistsArgumentNotDouble_InvalidFormatExceptionThrown() {
+    void parseServiceCharge_delimiterExistsArgumentNotNumeric_InvalidFormatExceptionThrown() {
+        // Standard non-numerics
         String argumentWithNonDoubleArgument =
                 "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7 /sc apple";
         try {
             double output = Parser.parseServiceCharge(argumentWithNonDoubleArgument);
+            fail();
+        } catch (InvalidFormatException exception) {
+            String errorMessage =
+                    Message.ERROR_PARSER_NON_PERCENTAGE_ARGUMENT + ParserUtils.SERVICE_CHARGE_DELIMITER;
+            assertEquals(errorMessage, exception.getMessage());
+        }
+
+        // Double.parseDouble reserved characters
+        String argumentWithReservedCharacters =
+                "/sid 3 /n Lunch /p Alice /i Alice Bob Charlie /co 15 /gst 7.0 /sc 10.0d";
+        try {
+            double output = Parser.parseServiceCharge(argumentWithReservedCharacters);
             fail();
         } catch (InvalidFormatException exception) {
             String errorMessage =

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -200,8 +200,24 @@ class ParserTest {
         String output = Parser.getRemainingArgument(fourInputTokensString);
         assertEquals("theLazy Dog", output);
     }
+    
+    // checkIfCommandIsValid()
+    /**
+     * Checks if an error message is returned if the user input contains any non-ASCII characters.
+     */
+    @Test
+    void checkIfCommandIsValid_nonAsciiInput_errorMessagePrinted() {
+        String commandInput = "session /create /n 予定 /d today /pl Alice Bob";
+        String commandType = Parser.getCommandType(commandInput);
+        if (commandType == null) {
+            fail();
+        }
+        String remainingArgs = Parser.getRemainingArgument(commandInput);
+        String errorMessage = ParserUtils.checkIfCommandIsValid(commandType, remainingArgs);
+        assertEquals(Message.ERROR_PARSER_NON_ASCII_ARGUMENT, errorMessage);
+    }
 
-    //  parseName()
+    // parseName()
     /**
      * Checks if an InvalidFormatException with the correct message is properly thrown
      * when the Name delimiter is not provided by the user.

--- a/src/test/java/seedu/splitlah/parser/ParserTest.java
+++ b/src/test/java/seedu/splitlah/parser/ParserTest.java
@@ -1,11 +1,19 @@
 package seedu.splitlah.parser;
 
 import org.junit.jupiter.api.Test;
+import seedu.splitlah.command.ActivityCreateCommand;
+import seedu.splitlah.command.ActivityDeleteCommand;
+import seedu.splitlah.command.ActivityEditCommand;
 import seedu.splitlah.command.Command;
+import seedu.splitlah.command.GroupEditCommand;
 import seedu.splitlah.command.HelpCommand;
 import seedu.splitlah.command.InvalidCommand;
+import seedu.splitlah.command.SessionCreateCommand;
+import seedu.splitlah.command.SessionDeleteCommand;
+import seedu.splitlah.command.SessionEditCommand;
 import seedu.splitlah.command.SessionListCommand;
 import seedu.splitlah.command.SessionSummaryCommand;
+import seedu.splitlah.command.SessionViewCommand;
 import seedu.splitlah.exceptions.InvalidFormatException;
 import seedu.splitlah.ui.Message;
 
@@ -24,13 +32,56 @@ class ParserTest {
     @Test
     void getCommand_validInput_validCommand() {
         // TODO: update with all Command subclasses after their CommandParser is complete
-        String sessionSummaryCommandInput = "session /summary /sid 1";
-        Command command = Parser.getCommand(sessionSummaryCommandInput);
-        assertEquals(SessionSummaryCommand.class, command.getClass());
+        String activityCreateCommandInput = "activity /create /sid 2 /n Class Lunch /p Alice /i Alice Bob /co 10";
+        Command command = Parser.getCommand(activityCreateCommandInput);
+        assertEquals(ActivityCreateCommand.class, command.getClass());
+
+        String activityDeleteCommandInput = "activity /delete /sid 2 /aid 1";
+        command = Parser.getCommand(activityDeleteCommandInput);
+        assertEquals(ActivityDeleteCommand.class, command.getClass());
+
+        String activityEditCommandInput = 
+                "activity /edit /sid 1 /aid 1 /n Dinner /p Bob /i Alice Bob /co 30 /gst 7 /sc 10";
+        command = Parser.getCommand(activityEditCommandInput);
+        assertEquals(ActivityEditCommand.class, command.getClass());
+
+        // TODO: Add missing: ActivityList, ActivityView, GroupCreate, GroupDelete
+        
+        String groupEditCommandInput = "group /edit /gid 1 /n Class gathering";
+        command = Parser.getCommand(groupEditCommandInput);
+        assertEquals(GroupEditCommand.class, command.getClass());
+
+        String groupListCommandInput = "group /list";
+        command = Parser.getCommand(groupEditCommandInput);
+        assertEquals(GroupEditCommand.class, command.getClass());
+
+        String groupViewCommandInput = "group /view /gid 1";
+        command = Parser.getCommand(groupEditCommandInput);
+        assertEquals(GroupEditCommand.class, command.getClass());
+
+        String sessionCreateCommandInput = "session /create /n Class Gathering /d 16-04-2022 /gid 1 /pl Alice";
+        command = Parser.getCommand(sessionCreateCommandInput);
+        assertEquals(SessionCreateCommand.class, command.getClass());
+
+        String sessionDeleteCommandInput = "session /delete /sid 1";
+        command = Parser.getCommand(sessionDeleteCommandInput);
+        assertEquals(SessionDeleteCommand.class, command.getClass());
+
+        String sessionEditCommandInput = "session /edit /sid 1 /n Class gathering /d 16-03-2022";
+        command = Parser.getCommand(sessionEditCommandInput);
+        assertEquals(SessionEditCommand.class, command.getClass());
         
         String sessionListCommandInput = "session /list";
         command = Parser.getCommand(sessionListCommandInput);
         assertEquals(SessionListCommand.class, command.getClass());
+
+        String sessionViewCommandInput = "session /view /sid 1";
+        command = Parser.getCommand(sessionViewCommandInput);
+        assertEquals(SessionViewCommand.class, command.getClass());
+        
+        String sessionSummaryCommandInput = "session /summary /sid 1";
+        command = Parser.getCommand(sessionSummaryCommandInput);
+        assertEquals(SessionSummaryCommand.class, command.getClass());
         
         String helpCommandInput = "help";
         command = Parser.getCommand(helpCommandInput);


### PR DESCRIPTION
Fix double parsing to prevent usage of characters such as 'd', 'f' or 'e' which is permitted in Double.parseDouble()
Fix non-ASCII input parsing

Fixes #415 
Fixes #417 
Fixes #423 